### PR TITLE
submit feedback on error code 8

### DIFF
--- a/lib/pushr/daemon/apns_support/connection_apns.rb
+++ b/lib/pushr/daemon/apns_support/connection_apns.rb
@@ -101,6 +101,8 @@ module Pushr
               if code.to_i == 8
                 Pushr::FeedbackApns.create(app: @configuration.app, device: notification.device, follow_up: 'delete',
                                            failed_at: Time.now)
+                Pushr::Daemon.logger.info("[#{@name}] Invalid device (error 8), feedback sent, message delivery failed"\
+                                          " to #{notification.to_json}")
               else
                 description = APN_ERRORS[code.to_i] || 'Unknown error. Possible push bug?'
                 error = Pushr::Daemon::DeliveryError.new(code, notification, description, 'APNS')

--- a/lib/pushr/daemon/apns_support/connection_apns.rb
+++ b/lib/pushr/daemon/apns_support/connection_apns.rb
@@ -98,8 +98,13 @@ module Pushr
             if tuple = read(ERROR_TUPLE_BYTES)
               _, code, notification_id = tuple.unpack('ccN')
 
-              description = APN_ERRORS[code.to_i] || 'Unknown error. Possible push bug?'
-              error = Pushr::Daemon::DeliveryError.new(code, notification, description, 'APNS')
+              if code.to_i == 8
+                Pushr::FeedbackApns.create(app: @configuration.app, device: notification.device, follow_up: 'delete',
+                                           failed_at: Time.now)
+              else
+                description = APN_ERRORS[code.to_i] || 'Unknown error. Possible push bug?'
+                error = Pushr::Daemon::DeliveryError.new(code, notification, description, 'APNS')
+              end
             else
               error = DisconnectionError.new
             end


### PR DESCRIPTION
@ThomasAlxDmy and @tilo I've added an if statement which creates an APNS feedback notification when error 8 is detected. I've received error 8 only in production with development devices. Do you guys agree?

Cheers!